### PR TITLE
Fix double update when syncing `value`

### DIFF
--- a/tests/integration/components/ember-ace-test.js
+++ b/tests/integration/components/ember-ace-test.js
@@ -39,13 +39,24 @@ test('leading, trailing and internal whitespace', function(assert) {
   assert.equal(this.component.value, this.get('value').trim());
 });
 
-test('notifying value updates', function(assert) {
+test('internal value updates', function(assert) {
   this.set('change', sinon.spy());
   this.render(hbs`{{ember-ace lines=1 update=(action change)}}`);
 
   this.component.setValue('hello');
   assert.ok(this.get('change').calledWith('hello'));
+  assert.equal(this.get('change.callCount'), 1);
   assert.equal(this.component.value, 'hello');
+});
+
+test('external value updates', function(assert) {
+  this.set('value', 'one');
+  this.set('change', sinon.spy());
+  this.render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
+
+  Ember.run(() => this.set('value', 'two'));
+  assert.equal(this.get('change.callCount'), 0);
+  assert.equal(this.component.value, 'two');
 });
 
 test('setting a theme', function(assert) {


### PR DESCRIPTION
Prior to this, updating the `value` property on the component would cause the `update` action to be invoked twice: once with `''`, and once with the actual value. This is due to the way Ace's own `setValue` method triggers `change` events.

With this change, setting `value` doesn't cause `update` to be invoked at all, which is consistent with how native HTML inputs work, as well as other DDAU-oriented Ember components like [ember-one-way-controls](https://github.com/DockYard/ember-one-way-controls).

This should fix #6 (/cc @bdiz)