### PR TITLE
Allow worker path to be specified in the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For each of the following types, you may specify an array of names to be include
  - `exts`: editor extensions, like spellcheck and Emmet abbreviations ([see all](https://github.com/ajaxorg/ace/tree/master/lib/ace/ext))
  - `keybindings`: common keybindings from editors like Emacs and Vim ([see all](https://github.com/ajaxorg/ace/tree/master/lib/ace/keyboard))
 
-If you need to customize the worker path you can specifying `workerPath` in the ace build config.
+If you need to customize the worker path you can specify `workerPath` in the ace build config.
 
 ```js
 new EmberApp(defaults, {

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ For each of the following types, you may specify an array of names to be include
  - `exts`: editor extensions, like spellcheck and Emmet abbreviations ([see all](https://github.com/ajaxorg/ace/tree/master/lib/ace/ext))
  - `keybindings`: common keybindings from editors like Emacs and Vim ([see all](https://github.com/ajaxorg/ace/tree/master/lib/ace/keyboard))
 
+If you need to customize the worker path you can specifying `workerPath` in the ace build config.
+
+```js
+new EmberApp(defaults, {
+  ace: {
+    ...
+    workerPath: '/my/custom/worker-path'
+  }
+});
+```
+
 ### Autocompletion
 **Note**: completion requires the language tools extension to be included. You'll need to set `exts: ['language_tools']` in your configuration in order for autocomplete to work.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For each of the following types, you may specify an array of names to be include
  - `exts`: editor extensions, like spellcheck and Emmet abbreviations ([see all](https://github.com/ajaxorg/ace/tree/master/lib/ace/ext))
  - `keybindings`: common keybindings from editors like Emacs and Vim ([see all](https://github.com/ajaxorg/ace/tree/master/lib/ace/keyboard))
 
-If you need to customize the worker path you can specify `workerPath` in the ace build config.
+If you need to customize the worker path you can specify `workerPath` in the build configuration.
 
 ```js
 new EmberApp(defaults, {

--- a/index.js
+++ b/index.js
@@ -59,8 +59,9 @@ function calculatePublicFiles(options) {
 function calculateWorkerPaths(options) {
   var workers = {};
   if (options.workers) {
+    var workerPath = options.workerPath || '/assets/ace';
     options.workers.forEach(function(name) {
-      workers['ace/mode/' + name + '_worker'] = '/js/course-designer/assets/ace/worker-' + name + '.js';
+      workers['ace/mode/' + name + '_worker'] = workerPath + '/worker-' + name + '.js';
     });
   }
   return workers;

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function calculateWorkerPaths(options) {
   var workers = {};
   if (options.workers) {
     options.workers.forEach(function(name) {
-      workers['ace/mode/' + name + '_worker'] = '/assets/ace/worker-' + name + '.js';
+      workers['ace/mode/' + name + '_worker'] = '/js/course-designer/assets/ace/worker-' + name + '.js';
     });
   }
   return workers;


### PR DESCRIPTION
This PR proposes  an option to specify a custom `workerPath` in the `ace` options.

```js
// ember-cli-build.js
ace: {
  themes: [...],
  modes: [...],
  workers: [...],
  workerPath: '/my/custom/worker-path'
},
```