### PR TITLE
Autocomplete null pointer exception

### DIFF
--- a/addon/components/ember-ace.js
+++ b/addon/components/ember-ace.js
@@ -177,9 +177,11 @@ export default Component.extend({
     if (this.editor) {
       const { completer } = this.editor;
       if (completer) {
-        // autocomplete doesn't clean itself up well
-        completer.popup.container.remove();
-        completer.popup.destroy();
+        // autocomplete options may have been initialized without a popup ever rendering
+        if (completer.popup) {
+          completer.popup.container.remove();
+          completer.popup.destroy();
+        }
         completer.detach();
       }
 


### PR DESCRIPTION
Awesome work on this adapter!
This addresses an unchecked reference to `popup` that can prevent proper cleanup when no popup was ever rendered.