### PR TITLE
Fixes aceOptions being ignored when installed as a nested addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   included: function(parent) {
-    this.aceOptions = (parent.app.options || parent.options || {}).ace || {};
+    this.aceOptions = (parent.options || parent.app.options || {}).ace || {};
     this._super.included.apply(this, arguments);
   },
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   included: function(parent) {
-    this.aceOptions = (parent.options || {}).ace || {};
+    this.aceOptions = (parent.app.options || parent.options || {}).ace || {};
     this._super.included.apply(this, arguments);
   },
 


### PR DESCRIPTION
When running ember-ace as part of an in-repo addon, any options specified in ember-cli-build.js of the consuming application are ignored.  This PR modifies the included hook to also look for ace configuration in parent.app.options.