### PR TITLE
Added: 'inFront' is a configurable property when creating overlays

### DIFF
--- a/addon/components/ember-ace.js
+++ b/addon/components/ember-ace.js
@@ -54,7 +54,7 @@ export default Component.extend({
     return overlays.map((overlay) => ({
       class: `ember-ace-${overlay.type} ${overlay.class || ''}`,
       range: overlay.range,
-      inFront: true,
+      inFront: overlay.hasOwnProperty('inFront') ? overlay.inFront : true,
     }));
   }),
 


### PR DESCRIPTION
I had a situation where I wanted to make some yellow highlighting appear behind some text in the editor. I couldn't figure out how to do it using the existing overlay API so I added this check to open up `inFront` as a configurable property. It'll still default to `true` if the user does not specify anything for `inFront`