### PR TITLE
Only call 'update' once per setValue

### DIFF
--- a/addon/components/ember-ace.js
+++ b/addon/components/ember-ace.js
@@ -92,25 +92,25 @@ export default Component.extend({
 
     this._syncAceProperties();
 
-    let settingValue = false;
-    let newValue = null;
-
     const originalSetValue = editor.setValue;
-    editor.setValue = function(value) {
-      newValue = value;
-      settingValue = true;
-      originalSetValue.call(editor, ...arguments);
-      settingValue = false;
+    editor.setValue = (...args) => {
+      const wasSilenced = this._silenceUpdates;
+      const update = this.get('update');
+
+      // Ace implements document.setValue by first removing and then inserting,
+      // so silence regular updates here, and instead call update directly 
+      this._silenceUpdates = true;
+      originalSetValue.call(editor, ...args);
+      this._silenceUpdates = wasSilenced;
+
+      if (update && !wasSilenced) {
+        run(() => update(editor.session.getValue()));
+      }
     }
 
     editor.getSession().on('change', (event, session) => {
       const update = this.get('update');
 
-      // Ace implements document.setValue by first removing and then inserting
-      // These checks prevent ember-ace from triggering 'update' more than once per setValue
-      if (settingValue && newValue && event.action === 'remove') {
-        return;
-      }
       if (update && !this._silenceUpdates) {
         run(() => update(session.getValue()));
       }

--- a/addon/components/ember-ace.js
+++ b/addon/components/ember-ace.js
@@ -98,10 +98,10 @@ export default Component.extend({
       const update = this.get('update');
 
       // Ace implements document.setValue by first removing and then inserting,
-      // so silence regular updates here, and instead call update directly 
-      this._silenceUpdates = true;
-      originalSetValue.call(editor, ...args);
-      this._silenceUpdates = wasSilenced;
+      // so silence regular updates here, and instead call update directly
+      this._withUpdatesSilenced(() => {
+        originalSetValue.call(editor, ...args);
+      })
 
       if (update && !wasSilenced) {
         run(() => update(editor.session.getValue()));

--- a/addon/components/ember-ace.js
+++ b/addon/components/ember-ace.js
@@ -94,7 +94,6 @@ export default Component.extend({
 
     const originalSetValue = editor.setValue;
     editor.setValue = (...args) => {
-      const wasSilenced = this._silenceUpdates;
       const update = this.get('update');
 
       // Ace implements document.setValue by first removing and then inserting,
@@ -103,7 +102,7 @@ export default Component.extend({
         originalSetValue.call(editor, ...args);
       })
 
-      if (update && !wasSilenced) {
+      if (update && !this._silenceUpdates) {
         run(() => update(editor.session.getValue()));
       }
     }

--- a/tests/integration/components/ember-ace-test.js
+++ b/tests/integration/components/ember-ace-test.js
@@ -53,21 +53,21 @@ module('Integration | Component | ember ace', function(hooks) {
   test('internal value updates with initial value', async function(assert) {
     this.set('value', 'one');
     this.set('change', sinon.spy());
-    this.render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
+    await render(hbs`{{ember-ace lines=1 update=(action change)}}`);
 
-    await this.component.setValue('two');
+    this.component.setValue('two');
     assert.equal(this.get('change.callCount'), 1);
     assert.equal(this.component.value, 'two');
 
-    await this.component.setValue('');
+    this.component.setValue('');
     assert.equal(this.get('change.callCount'), 2);
     assert.equal(this.component.value, '');
   });
 
-  test('external value updates', function(assert) {
+  test('external value updates', async function(assert) {
     this.set('value', 'one');
     this.set('change', sinon.spy());
-    this.render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
+    await render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
 
     run(() => this.set('value', 'two'));
     assert.equal(this.get('change.callCount'), 0);

--- a/tests/integration/components/ember-ace-test.js
+++ b/tests/integration/components/ember-ace-test.js
@@ -50,10 +50,24 @@ module('Integration | Component | ember ace', function(hooks) {
     assert.equal(this.component.value, 'hello');
   });
 
-  test('external value updates', async function(assert) {
+  test('internal value updates with initial value', async function(assert) {
     this.set('value', 'one');
     this.set('change', sinon.spy());
-    await render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
+    this.render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
+
+    await this.component.setValue('two');
+    assert.equal(this.get('change.callCount'), 1);
+    assert.equal(this.component.value, 'two');
+
+    await this.component.setValue('');
+    assert.equal(this.get('change.callCount'), 2);
+    assert.equal(this.component.value, '');
+  });
+
+  test('external value updates', function(assert) {
+    this.set('value', 'one');
+    this.set('change', sinon.spy());
+    this.render(hbs`{{ember-ace lines=1 value=value update=(action change)}}`);
 
     run(() => this.set('value', 'two'));
     assert.equal(this.get('change.callCount'), 0);


### PR DESCRIPTION
Ace [implements setValue](https://github.com/ajaxorg/ace/blob/master/lib/ace/document.js#L77-L80) by first removing old content and then inserting new content.

What this means for `ember-ace` is that it invokes `update` twice when using setValue.

This is a hack to ensure `update` is only invoked once when setValue is called with a truthy value. When setValue is called with a falsy value, the editor is being cleared and `update` is invoked as usual.