### PR TITLE
Use rootURL for default workerPath

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,6 +9,7 @@ module.exports = function() {
     getChannelURL('canary')
   ]).then((urls) => {
     return {
+      useYarn: true,
       scenarios: [
         {
           name: 'ember-lts-2.12',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = {
   name: 'ember-ace',
@@ -22,7 +23,7 @@ module.exports = {
 
   treeForAddon: function(tree) {
     var WorkerManifest = require('./lib/worker-manifest');
-    var rootURL = this.project.config(this.env).rootURL;
+    var rootURL = this.project.config(EmberApp.env()).rootURL;
     var manifest = new WorkerManifest({
       workerPaths: calculateWorkerPaths(this.aceOptions, rootURL)
     });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+// eslint-disable-next-line node/no-unpublished-require
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -22,8 +22,9 @@ module.exports = {
 
   treeForAddon: function(tree) {
     var WorkerManifest = require('./lib/worker-manifest');
+    var rootURL = this.project.config(this.env).rootURL;
     var manifest = new WorkerManifest({
-      workerPaths: calculateWorkerPaths(this.aceOptions)
+      workerPaths: calculateWorkerPaths(this.aceOptions, rootURL)
     });
 
     var merged = require('broccoli-merge-trees')([tree, manifest]);
@@ -54,10 +55,10 @@ function calculatePublicFiles(options) {
   }
 }
 
-function calculateWorkerPaths(options) {
+function calculateWorkerPaths(options, appRootURL) {
   var workers = {};
   if (options.workers) {
-    var workerPath = options.workerPath || '/assets/ace';
+    var workerPath = options.workerPath || `${appRootURL}assets/ace`;
     options.workers.forEach(function(name) {
       workers['ace/mode/' + name + '_worker'] = workerPath + '/worker-' + name + '.js';
     });


### PR DESCRIPTION
**Problem**
The default `workerPath` incorrectly points to the top-level file path. For any `rootURL` the workerPath is always:
```
https://example.com/assets/ace
```

**Solution**
Because Ember assets are deployed relative to the `rootURL`, this addon should use the app's configuration when constructing the default workerPath. For example, given `rootURL: "/my/awesome/app/"`, the `workerPath` should be:
```
https://example.com/my/awesome/app/assets/ace
```

**Assumptions**
It is my understanding that app `rootURL`s always need a leading and trailing slash. If this is not the case, I'll have to update the solution to ensure a standard format.